### PR TITLE
Indicate LinkedIn is protecting its data, not being nefarious

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 LinkedIn protects their own users' privacy in an effort to reduce the amount of unsolicted
 spam via browser extensions. At the time of writing this, LinkedIn is scanning visitors 
-for 38 different scammy browser extensions. 
+for 86 different recruiting and sales focused browser extensions. 
 
 I will dive into how LinkedIn detects extensions and what extension developers 
 can do to prevent detection. 
@@ -135,7 +135,7 @@ much harder if not impossible.
 
 4. Don't be spammy
 
-LinkedIn only detects extensiosn that are used to harvest emails for the sake of
+LinkedIn only detects extensions that are used to harvest emails for the sake of
 recruiting or sales leads. If you're doing anything else (blocking ads, autofilling
 passwords, changing the theme), you'll be fine!
     

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Helpful LinkedIn 
+# LinkedIn Data-Scraping Detection
 
 LinkedIn protects their own users' privacy in an effort to reduce the amount of unsolicted
 spam via browser extensions. At the time of writing this, LinkedIn is scanning visitors 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Nefarious LinkedIn 
+# Helpful LinkedIn 
 
-LinkedIn violates their own users' privacy in an effort to detect the usage of 
-browser extensions. At the time of writing this, LinkedIn is scanning visitors 
-for 38 different browser extensions. 
+LinkedIn protects their own users' privacy in an effort to reduce the amount of unsolicted
+spam via browser extensions. At the time of writing this, LinkedIn is scanning visitors 
+for 38 different scammy browser extensions. 
 
 I will dive into how LinkedIn detects extensions and what extension developers 
 can do to prevent detection. 
@@ -44,7 +44,7 @@ is making requests to files located in your browser itself.
 I have attached a little animated gif showing what these requests look like on 
 LinkedIn. 
 
-![LinkedIn Spying](./images/spying.gif "LinkedIn Spying")
+![LinkedIn Spying](./images/spying.gif "LinkedIn Protecting")
 
 In this case, the presence of an error message indicates the resource was not 
 available and therefore the extension they were looking for is not installed on
@@ -132,6 +132,12 @@ if you want to isolate your extension from the web page you must do this.
 Consider using a browser action instead of modifying the page via content 
 scripts. Browser actions run in an isolated environment and makes detecting them
 much harder if not impossible. 
+
+4. Don't be spammy
+
+LinkedIn only detects extensiosn that are used to harvest emails for the sake of
+recruiting or sales leads. If you're doing anything else (blocking ads, autofilling
+passwords, changing the theme), you'll be fine!
     
 ### Credit 
 


### PR DESCRIPTION
Since the only extensions that LinkedIn detects are ones that are used for spamming users, I've reworded this extension to properly reflect why it's happening. FUD against LinkedIn is unfair in this case, since their only goal is to reduce unsolicited emails sent to their users and prevent data collection by unauthorized third parties.